### PR TITLE
[DLST 469] Validate that all checksums are unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Alternatively, you can run your own server to use as the test transfer server. T
 3.  All files listed in the manifest file are accounted for
     3.1.  All files listed in the manifest exist in the downloaded temp directory
     3.2.  All files in the downloaded temp directory (besides metadata files) are listed in the manifest
-4.  The checksums listed for each file in the manifest match the checksums for what was downloaded
+4. The manifest file is valid
+    4.1 The checksums listed for each file in the manifest match the checksums for what was downloaded
+    4.2 Each checksum listed in the manifest file is unique
 ```
 
 ### Expected transfer server directory structure

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -25,12 +25,3 @@ set :job_template, "/usr/local/bin/mailifrc -s 'Error - :email_subject' :error_r
 #   command "#{@rvm_command_prefix} #{@path}/gsas_sync_main.rb"
 # end
 ################################################################################
-
-# every 1.minute do
-#   # The following format works for running a ruby script:
-#   # command "#{@rvm_command_prefix} #{@path}/testscript.rb"
-# end
-
-# every :month do
-# command 'ruby /tmp/gsas_deployment_testing/gsas_sync_staging/current/gsas_sync_main.rb --log-level fatal'
-# end

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -257,13 +257,17 @@ class Validator
     end
     valid = true
     @manifest_hash.each do |file_path, checksum|
-      next if @digest_class.file(file_path).hexdigest.upcase == checksum.upcase
+      next if hex_checksums_match?(@digest_class.file(file_path).hexdigest, checksum)
 
       GsasSync::Logger.log_all_warn("Checksum does not match manifest value: #{file_path}")
       valid = false
     end
     log_validation_result(valid, 'All checksum values match manifest')
     valid
+  end
+
+  def hex_checksums_match?(sum1, sum2)
+    sum1.upcase == sum2.upcase
   end
 
   private

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -17,7 +17,8 @@ require 'cul/preservation_utils'
 # 3.  : All files listed in the manifest file are accounted for
 # 3.1 : All files listed in the manifest exist in the downloaded temp directory
 # 3.2 : All files in the downloaded temp directory (besides metadata files) are listed in the manifest
-# 4.  : The checksums listed for each file in the manifest match the checksums for what was downloaded
+# 4.1 : The checksums listed for each file in the manifest match the checksums for what was downloaded
+# 4.2 : Each checksum listed in the manifest file is unique
 class Validator
   DATE_PREFIX_LEN = 7
   DISSERTATION_DIR_REGEX = /^\d{4}_\d{2}_dissertations$/
@@ -255,6 +256,34 @@ class Validator
       GsasSync::Logger.log_all_warn('Invalid manifest file or checksum algorithm. Unable to validate checksums.')
       return false
     end
+
+    valid = checksums_match?
+    valid &= checksums_unique?
+
+    log_validation_result(valid, 'All checksum values match manifest')
+    valid
+  end
+
+  # Returns true if the checksums listed in the manifest file are all unique among one another
+  def checksums_unique?
+    hash_copy = {}
+    result = true
+    @manifest_hash.each do |filepath, checksum|
+      if hash_copy.key?(checksum)
+        GsasSync::Logger.log_all_warn("The checksums listed in the manifest file are not unique; a duplicate file may have been uploaded. Suspicious files: #{filepath} & #{hash_copy[checksum]}.") # rubocop:disable Layout/LineLength
+        result = false
+        next
+      end
+
+      hash_copy[checksum] = filepath
+    end
+
+    result
+  end
+
+  # Returns true if the checksums listed in the manifest match the calculated checksums of the
+  # files that were downloaded
+  def checksums_match?
     valid = true
     @manifest_hash.each do |file_path, checksum|
       next if hex_checksums_match?(@digest_class.file(file_path).hexdigest, checksum)
@@ -262,7 +291,6 @@ class Validator
       GsasSync::Logger.log_all_warn("Checksum does not match manifest value: #{file_path}")
       valid = false
     end
-    log_validation_result(valid, 'All checksum values match manifest')
     valid
   end
 

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Validator do
   let(:expected_test_manifest_hash) { { base_dir.join('data/file.txt').to_s => empty_file_checksum } }
   let(:expected_test_manifest_hash_diff_cases) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_diff_cases } } # rubocop:disable Layout/LineLength
   let(:expected_test_manifest_hash_md5) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_md5 } }
+  let(:expected_test_manifest_hash_not_unique) do
+    { base_dir.join('data/file.txt').to_s => empty_file_checksum,
+      base_dir.join('data/file2.txt').to_s => empty_file_checksum }
+  end
   let(:test_downloaded_files_array) { [base_dir.join('data/file.txt').to_s] }
   let(:digest_class_double) { class_double(Digest::SHA256) }
   let(:digest_class_double_md5) { class_double(Digest::MD5) }
@@ -583,7 +587,9 @@ RSpec.describe Validator do
   end
 
   describe '#valid_checksums?' do
-    let(:digest_instance_double) { instance_double(Digest::Instance) }
+    before do
+      allow(test_validator).to receive(:log_validation_result)
+    end
 
     context 'if #valid_manifest_and_digest_instance_variables? returns false' do
       before do
@@ -600,30 +606,58 @@ RSpec.describe Validator do
       end
     end
 
-    context 'with a successful transfer' do
+    context 'with valid checksums' do
       before do
         allow(test_validator).to receive(:valid_manifest_and_digest_instance_variables?).and_return(true)
-        allow(test_validator).to receive(:log_validation_result)
+        allow(test_validator).to receive(:checksums_match?).and_return(true)
+        allow(test_validator).to receive(:checksums_unique?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(test_validator.valid_checksums?).to be(true)
+      end
+    end
+  end
+
+  describe '#checksums_match?' do
+    let(:digest_instance_double) { instance_double(Digest::Instance) }
+
+    context 'with valid checksums' do
+      before do
         test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
-        # test_validator.instance_variable_set(:@digest_class, digest_class_double)
         test_validator.instance_variable_set(:@digest_class, digest_class_double)
         allow(digest_class_double).to receive(:file).and_return(digest_instance_double)
         allow(digest_instance_double).to receive(:hexdigest).and_return(empty_file_checksum)
       end
 
       it 'returns true' do
-        expect(test_validator.valid_checksums?).to be(true)
+        expect(test_validator.checksums_match?).to be(true)
       end
 
       it 'returns true even if the checksums use different cases' do
         test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash_diff_cases)
-        expect(test_validator.valid_checksums?).to be(true)
+        expect(test_validator.checksums_match?).to be(true)
       end
 
       it 'computes the checksum for each file in the @manifest_hash' do
         expect(digest_instance_double).to receive(:hexdigest).once
-        test_validator.valid_checksums?
+        test_validator.checksums_match?
       end
+    end
+  end
+
+  describe '#checksums_unique?' do
+    before do
+      test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
+    end
+
+    it 'returns true with a valid manifest file' do
+      expect(test_validator.checksums_unique?).to be(true)
+    end
+
+    it 'returns false with an invalid manifest file' do
+      test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash_not_unique)
+      expect(test_validator.checksums_unique?).to be(false)
     end
   end
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Validator do
   #  - WE USE THE DATE-PREFIX 2000_01
   #  - WE ASSUME THERE IS ONLY ONE file.txt IN data/, AND IT IS EMPTY #  - WE ASSUME THE MANIFEST FILE USES SHA256
   empty_file_checksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  empty_file_checksum_diff_cases = 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
   empty_file_checksum_md5 = 'd41d8cd98f00b204e9800998ecf8427e'
 
   let(:logger_double) { instance_double(Logger) }
@@ -15,6 +16,7 @@ RSpec.describe Validator do
   let(:num_nested_items) { 5 }
   let(:test_validator) { described_class.new(base_dir) }
   let(:expected_test_manifest_hash) { { base_dir.join('data/file.txt').to_s => empty_file_checksum } }
+  let(:expected_test_manifest_hash_diff_cases) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_diff_cases } } # rubocop:disable Layout/LineLength
   let(:expected_test_manifest_hash_md5) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_md5 } }
   let(:test_downloaded_files_array) { [base_dir.join('data/file.txt').to_s] }
   let(:digest_class_double) { class_double(Digest::SHA256) }
@@ -610,6 +612,11 @@ RSpec.describe Validator do
       end
 
       it 'returns true' do
+        expect(test_validator.valid_checksums?).to be(true)
+      end
+
+      it 'returns true even if the checksums use different cases' do
+        test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash_diff_cases)
         expect(test_validator.valid_checksums?).to be(true)
       end
 


### PR DESCRIPTION
Adds a validation rule checking that all the checksums listed in the manifest file are unique.

If they are not unique, it is likely that the same file was included twice in the deposit. This will be considered a failure and an error email will be sent.