### PR TITLE
[DLST 473] New validation rules for manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Alternatively, you can run your own server to use as the test transfer server. T
     1.3. An yyyy_mm_assets.csv file with a matching prefix exist
 2.  No undesireable characters are present in any of the file/directory names
 3.  All files listed in the manifest file are accounted for
-    3.1.  All files listed in the manifest exist in the downloaded temp directory
-    3.2.  All files in the downloaded temp directory (besides metadata files) are listed in the manifest
+    3.1.  All files listed in the manifest exist in the downloaded data/ temp directory
+    3.2 No metadata files (assets and items csv, e.g.) are listed in the manifest file
+    3.3.  All files in the downloaded temp directory (besides metadata files) are listed in the manifest
 4. The manifest file is valid
     4.1 The checksums listed for each file in the manifest match the checksums for what was downloaded
     4.2 Each checksum listed in the manifest file is unique

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -183,24 +183,28 @@ class Validator
   # directory.
   # Removes entries for any non-existent files and files not nested under data/ from the @manifest_hash
   def files_in_manifest_exist?
-    result = true
-    @manifest_hash.each_key do |file|
-      next if File.exist?(file) && file.split('/').include?('data')
+    missing_files = @manifest_hash.keys.reject { |file| File.exist?(file) && file.split('/').include?('data') }
 
+    missing_files.each do |file|
       GsasSync::Logger.log_all_warn("‼️ The file '#{file}' is listed in the manifest file but does not exist in the downloaded data/ directory") # rubocop:disable Layout/LineLength
-      result = false
+      @manifest_hash.delete file
     end
-    result
+
+    missing_files.empty?
   end
 
   # VALIDATION RULE 3.2
   # Returns true if there are no assets or items csv metadata files listed in the
   # manifest file (only non-metadata files nested under data/ should be there).
+  # Checks each file listed in the manifest
   def no_metadata_files_in_manifest?
-    @manifest_hash.each_key do |file|
-      return false if metadata_file? file
+    metadata_files = @manifest_hash.keys.select { |path| metadata_file? File.basename(path) }
+
+    metadata_files.each do |path|
+      GsasSync::Logger.log_all_warn("‼️ The #{File.basename(path)} metadata file should not be included in the manifest.") # rubocop:disable Layout/LineLength
     end
-    true
+
+    metadata_files.empty?
   end
 
   # VALIDATION RULE 3.3
@@ -208,23 +212,15 @@ class Validator
   def all_downloaded_files_in_manifest?
     raise GsasSync::Exceptions::GsasError, 'manifest hash is undefined' if @manifest_hash.nil?
 
-    downloaded_files_array = recursive_files_array(@dissertation_dir) # .sort
+    downloaded_files_array = recursive_files_array(@dissertation_dir)
+    # Any file that is not a key in the hash is unlisted
+    unlisted_files = downloaded_files_array.reject { |path| @manifest_hash.key? path }
 
-    result = true
-    downloaded_files_array.each do |file|
-      unless @manifest_hash.key? file
-        GsasSync::Logger.log_all_warn("‼️ The following file was downloaded, but is not listed in the manifest: #{file}") # rubocop:disable Layout/LineLength
-        result = false
-      end
+    unlisted_files.each do |path|
+      GsasSync::Logger.log_all_warn("‼️ The following file was downloaded, but is not listed in the manifest: #{path}")
     end
 
-    result
-
-    # return true if downloaded_files_array == manifest_files_array
-
-    # diff = downloaded_files_array - manifest_files_array
-    # GsasSync::Logger.log_all_warn("‼️ The following file(s) were downloaded, but are not listed in the manifest: #{diff}") # rubocop:disable Layout/LineLength
-    # false
+    unlisted_files.empty?
   end
 
   # Returns array containing filenames (as strings) of every file under the given parent directory, recursively

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -160,6 +160,7 @@ class Validator
 
     build_manifest_hash
     valid = files_in_manifest_exist?
+    valid &= no_metadata_files_in_manifest?
     valid &= all_downloaded_files_in_manifest?
     log_validation_result(valid, 'All files in manifest are accounted for')
     valid
@@ -178,40 +179,56 @@ class Validator
   end
 
   # VALIDATION RULE 3.1
-  # Returns false if any of the files listed in the manifest are not present in the downloaded @dissertation_dir
-  # Removes entries for any non-existent files from the @manifest_hash
+  # Returns false if any of the files listed in the manifest are not present in the downloaded @dissertation_dir/data
+  # directory.
+  # Removes entries for any non-existent files and files not nested under data/ from the @manifest_hash
   def files_in_manifest_exist?
     result = true
     @manifest_hash.each_key do |file|
-      puts "checking if this file from manifest exists in the downloaded dir: #{file}"
-      next if File.exist?(file)
+      next if File.exist?(file) && file.split('/').include?('data')
 
-      GsasSync::Logger.log_all_warn("‼️ The file #{file} is listed in the manifest file but does not exist in the downloaded directory") # rubocop:disable Layout/LineLength
-      @manifest_hash.delete(file)
+      GsasSync::Logger.log_all_warn("‼️ The file '#{file}' is listed in the manifest file but does not exist in the downloaded data/ directory") # rubocop:disable Layout/LineLength
       result = false
     end
     result
   end
 
   # VALIDATION RULE 3.2
-  # returns true if all files in the @dissertation_dir directory are listed in the manifest file
-  # TODO : We could use this same logic in #files_in_manifest_exist? ; it's just an array difference the other direction
-  # (manifest_files_array - downloaded_files_array) -- this may be a performant refactor to do in the future.
+  # Returns true if there are no assets or items csv metadata files listed in the
+  # manifest file (only non-metadata files nested under data/ should be there).
+  def no_metadata_files_in_manifest?
+    @manifest_hash.each_key do |file|
+      return false if metadata_file? file
+    end
+    true
+  end
+
+  # VALIDATION RULE 3.3
+  # returns true if all files in the @dissertation_dir/data directory are listed in the manifest file
   def all_downloaded_files_in_manifest?
     raise GsasSync::Exceptions::GsasError, 'manifest hash is undefined' if @manifest_hash.nil?
 
-    downloaded_files_array = recursive_files_array(@dissertation_dir).sort
-    manifest_files_array = @manifest_hash.keys.sort
+    downloaded_files_array = recursive_files_array(@dissertation_dir) # .sort
 
-    return true if downloaded_files_array == manifest_files_array
+    result = true
+    downloaded_files_array.each do |file|
+      unless @manifest_hash.key? file
+        GsasSync::Logger.log_all_warn("‼️ The following file was downloaded, but is not listed in the manifest: #{file}") # rubocop:disable Layout/LineLength
+        result = false
+      end
+    end
 
-    diff = downloaded_files_array - manifest_files_array
-    GsasSync::Logger.log_all_warn("‼️ The following file(s) were downloaded, but are not listed in the manifest: #{diff}") # rubocop:disable Layout/LineLength
-    false
+    result
+
+    # return true if downloaded_files_array == manifest_files_array
+
+    # diff = downloaded_files_array - manifest_files_array
+    # GsasSync::Logger.log_all_warn("‼️ The following file(s) were downloaded, but are not listed in the manifest: #{diff}") # rubocop:disable Layout/LineLength
+    # false
   end
 
   # Returns array containing filenames (as strings) of every file under the given parent directory, recursively
-  # including nested directory's files
+  # including nested directory's files -- EXCLUDING any metadata files.
   def recursive_files_array(parent = @dissertation_dir)
     array = []
     parent.each_child do |child|

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -183,6 +183,7 @@ class Validator
   def files_in_manifest_exist?
     result = true
     @manifest_hash.each_key do |file|
+      puts "checking if this file from manifest exists in the downloaded dir: #{file}"
       next if File.exist?(file)
 
       GsasSync::Logger.log_all_warn("‼️ The file #{file} is listed in the manifest file but does not exist in the downloaded directory") # rubocop:disable Layout/LineLength

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -159,7 +159,7 @@ class Validator
     return false unless valid_manifest_and_digest_instance_variables?
 
     build_manifest_hash
-    valid = files_in_manifest_exist?
+    valid = files_in_manifest_exist_in_data_dir?
     valid &= no_metadata_files_in_manifest?
     valid &= all_downloaded_files_in_manifest?
     log_validation_result(valid, 'All files in manifest are accounted for')
@@ -182,7 +182,7 @@ class Validator
   # Returns false if any of the files listed in the manifest are not present in the downloaded @dissertation_dir/data
   # directory.
   # Removes entries for any non-existent files and files not nested under data/ from the @manifest_hash
-  def files_in_manifest_exist?
+  def files_in_manifest_exist_in_data_dir?
     missing_files = @manifest_hash.keys.reject { |file| File.exist?(file) && file.split('/').include?('data') }
 
     missing_files.each do |file|

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -15,13 +15,22 @@ RSpec.describe Validator do
   let(:test_date_prefix_str) { '2000_01' }
   let(:num_nested_items) { 5 }
   let(:test_validator) { described_class.new(base_dir) }
-  let(:expected_test_manifest_hash) { { base_dir.join('data/file.txt').to_s => empty_file_checksum } }
-  let(:expected_test_manifest_hash_diff_cases) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_diff_cases } } # rubocop:disable Layout/LineLength
+  let(:test_manifest_hash) { { base_dir.join('data/file.txt').to_s => empty_file_checksum } }
+  let(:test_manifest_hash_diff_cases) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_diff_cases } }
   let(:expected_test_manifest_hash_md5) { { base_dir.join('data/file.txt').to_s => empty_file_checksum_md5 } }
-  let(:expected_test_manifest_hash_not_unique) do
+  let(:test_manifest_hash_not_unique) do
     { base_dir.join('data/file.txt').to_s => empty_file_checksum,
       base_dir.join('data/file2.txt').to_s => empty_file_checksum }
   end
+  let(:test_metatdata_hash_with_metadata_files) do
+    { base_dir.join('data/2000_01_items.csv') => 'abcd',
+      base_dir.join('data/2000_01_assets.csv') => 'abcd' }
+  end
+  let(:test_manifest_hash_not_in_data_dir) do
+    { base_dir.join('not_data/file1.csv') => 'abcd',
+      base_dir.join('not_data/file2.csv') => 'abcd' }
+  end
+
   let(:test_downloaded_files_array) { [base_dir.join('data/file.txt').to_s] }
   let(:digest_class_double) { class_double(Digest::SHA256) }
   let(:digest_class_double_md5) { class_double(Digest::MD5) }
@@ -390,7 +399,7 @@ RSpec.describe Validator do
     before do
       allow(test_validator).to receive(:valid_manifest_and_digest_instance_variables?).and_return(true)
       allow(test_validator).to receive(:build_manifest_hash)
-      allow(test_validator).to receive(:files_in_manifest_exist?).and_return(true)
+      allow(test_validator).to receive(:files_in_manifest_exist_in_data_dir?).and_return(true)
       allow(test_validator).to receive(:all_downloaded_files_in_manifest?).and_return(true)
       allow(test_validator).to receive(:log_validation_result)
       test_validator.instance_variable_set(:@manifest_filename, 'manifest-sha256.txt')
@@ -403,7 +412,7 @@ RSpec.describe Validator do
 
     it 'returns does not perform validations if #valid_manifest_and_digest_instance_variables returns false' do
       allow(test_validator).to receive(:valid_manifest_and_digest_instance_variables?).and_return(false)
-      expect(test_validator).not_to receive(:files_in_manifest_exist?)
+      expect(test_validator).not_to receive(:files_in_manifest_exist_in_data_dir?)
       expect(test_validator).not_to receive(:all_downloaded_files_in_manifest?)
     end
   end
@@ -414,16 +423,16 @@ RSpec.describe Validator do
       test_validator.instance_variable_set(:@manifest_filename, 'manifest-sha256.txt')
       test_validator.build_manifest_hash
 
-      expect(test_validator.instance_variable_get(:@manifest_hash)).to eq(expected_test_manifest_hash)
+      expect(test_validator.instance_variable_get(:@manifest_hash)).to eq(test_manifest_hash)
     end
   end
 
-  describe '#files_in_manifest_exist?' do
+  describe '#files_in_manifest_exist_in_data_dir?' do
     context 'given a manifest with all existing files' do
       it 'returns true' do
-        test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
+        test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash)
 
-        expect(test_validator.files_in_manifest_exist?).to be(true)
+        expect(test_validator.files_in_manifest_exist_in_data_dir?).to be(true)
       end
     end
 
@@ -433,24 +442,68 @@ RSpec.describe Validator do
       end
 
       it 'returns false' do
-        expect(test_validator.files_in_manifest_exist?).to be(false)
+        expect(test_validator.files_in_manifest_exist_in_data_dir?).to be(false)
       end
 
       it 'logs a warning to all' do
         expect(GsasSync::Logger).to receive(:log_all_warn)
-        test_validator.files_in_manifest_exist?
+        test_validator.files_in_manifest_exist_in_data_dir?
       end
 
       it 'deletes the missing file from the @manifest_hash object' do
-        test_validator.files_in_manifest_exist?
+        test_validator.files_in_manifest_exist_in_data_dir?
         expect(test_validator.instance_variable_get(:@manifest_hash)).to eq({})
+      end
+    end
+
+    context 'given a manifest with files not in data/ directory' do
+      before do
+        test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash_not_in_data_dir)
+      end
+
+      it 'returns false' do
+        expect(test_validator.files_in_manifest_exist_in_data_dir?).to be(false)
+      end
+
+      it 'logs each offending file' do
+        expect(GsasSync::Logger).to receive(:log_all_warn).twice
+        test_validator.files_in_manifest_exist_in_data_dir?
+      end
+    end
+  end
+
+  describe '#no_metadata_files_in_manifest?' do
+    context 'when the manifest is valid' do
+      before do
+        test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash)
+        allow(test_validator).to receive(:metadata_file?).and_return false
+      end
+
+      it 'returns true if there are no metadata files in the manifest' do
+        expect(test_validator.no_metadata_files_in_manifest?).to be(true)
+      end
+    end
+
+    context 'when the manifest is invalid' do
+      before do
+        test_validator.instance_variable_set(:@manifest_hash, test_metatdata_hash_with_metadata_files)
+        allow(test_validator).to receive(:metadata_file?).and_return true
+      end
+
+      it 'returns false if there is a metadata file in the manifest' do
+        expect(test_validator.no_metadata_files_in_manifest?).to be(false)
+      end
+
+      it 'logs all offending files when multiple' do
+        expect(GsasSync::Logger).to receive(:log_all_warn).twice
+        test_validator.no_metadata_files_in_manifest?
       end
     end
   end
 
   describe '#all_downloaded_files_in_manifest?' do
     before do
-      test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
+      test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash)
       allow(test_validator).to receive(:recursive_files_array).and_return(test_downloaded_files_array)
     end
 
@@ -624,7 +677,7 @@ RSpec.describe Validator do
 
     context 'with valid checksums' do
       before do
-        test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
+        test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash)
         test_validator.instance_variable_set(:@digest_class, digest_class_double)
         allow(digest_class_double).to receive(:file).and_return(digest_instance_double)
         allow(digest_instance_double).to receive(:hexdigest).and_return(empty_file_checksum)
@@ -635,7 +688,7 @@ RSpec.describe Validator do
       end
 
       it 'returns true even if the checksums use different cases' do
-        test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash_diff_cases)
+        test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash_diff_cases)
         expect(test_validator.checksums_match?).to be(true)
       end
 
@@ -648,7 +701,7 @@ RSpec.describe Validator do
 
   describe '#checksums_unique?' do
     before do
-      test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash)
+      test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash)
     end
 
     it 'returns true with a valid manifest file' do
@@ -656,7 +709,7 @@ RSpec.describe Validator do
     end
 
     it 'returns false with an invalid manifest file' do
-      test_validator.instance_variable_set(:@manifest_hash, expected_test_manifest_hash_not_unique)
+      test_validator.instance_variable_set(:@manifest_hash, test_manifest_hash_not_unique)
       expect(test_validator.checksums_unique?).to be(false)
     end
   end


### PR DESCRIPTION
### [Jira Ticket](https://columbiauniversitylibraries.atlassian.net/browse/DLST-473)
***
This PR adds a new validation rule and alters another:
- "3.1 Files in manifest exist" is changed to "3.1 Files in manifest exist in the data/ directory"
  - This ensures that the package is structured properly
- A new validation rule "3.2 No metadata Files in the manifest" was created
  - This explicitly checks that metadata files like the assets and items csv files are not included in the manifest file