### PR TITLE
final deployment changes

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,8 +9,6 @@ set :repo_url, "git@github.com:cul/#{fetch(:repo_name)}.git/"
 set :deploy_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 set :remote_user, 'ldpdserv' # because we are accessing preservation storage
 
-ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
-
 # deploy_name = gsas_sync_{dev|test|prod}
 set :deploy_to, -> { "/opt/scripts/#{fetch(:deploy_name)}" }
 

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -2,3 +2,5 @@
 
 set :stage, :dev
 server 'diglib-service-prod1.cul.columbia.edu', user: fetch(:remote_user)
+
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,3 +2,6 @@
 
 set :stage, :prod
 server 'diglib-service-prod1.cul.columbia.edu', user: fetch(:remote_user), roles: %w[production_app]
+
+# Grab latest tag version
+ask :branch, proc { `git tag --sort=version:refname`.split("\n").last }

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -2,3 +2,5 @@
 
 set :stage, :test
 server 'diglib-service-prod1.cul.columbia.edu', user: fetch(:remote_user)
+
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,7 +7,7 @@
 # Learn more: http://github.com/javan/whenever
 
 # Log cron output to app log directory
-# set :output, ("shared/log/#{Rails.env}_cron_log.log")
+set :output, "#{path}/logs/#{@script_env}_cron_log.log"
 
 # Our job template wraps the cron job in a script that emails out any unhandled errors.
 # This is a CUL provided script. More details can be found here:
@@ -21,7 +21,9 @@ set :job_template, "/usr/local/bin/mailifrc -s 'Error - :email_subject' :error_r
 
 ############################  COMMAND  #########################################
 # Run dissertation sync script once a day on days 1-7 of each month:
-# every '0 0 1-7 * *' do
-#   command "#{@rvm_command_prefix} #{@path}/gsas_sync_main.rb"
-# end
+every '0 0 1-7 * *', at: '12:01 am' do
+  unless @script_env == 'gsas_sync_prod' # rubocop:disable Style/IfUnlessModifier
+    command "#{@rvm_command_prefix} #{@path}/gsas_sync_main.rb"
+  end
+end
 ################################################################################


### PR DESCRIPTION
This PR contains some final deployment changes; now deploying to prod will schedule a cron job to run for the first 7 days of each month at 12:01 am.

in particular:
- grab the latest tag version when deploying to prod; to dev and test, ask for latest branch
- the schedule.rb file now will create a cron job if the environment is 'gsas_sync_prod'
- log cron output to ./logs/gsas_sync_prod_cron_log.log